### PR TITLE
Disable parallel tests

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,4 @@
-import org.gradle.api.tasks.testing.logging.TestLogEvent.*
+import org.gradle.api.tasks.testing.logging.TestLogEvent.FAILED
 
 plugins {
   application
@@ -31,7 +31,6 @@ tasks.test {
   testLogging {
     events(FAILED)
   }
-  maxParallelForks = Runtime.getRuntime().availableProcessors()
 }
 
 application {


### PR DESCRIPTION
I suspect that CircleCI flakes like these are due to non-safe parallel tests:

- https://app.circleci.com/pipelines/github/oliver-charlesworth/nespot/258/workflows/e6397fe5-b6b8-4802-964b-593269a5cdc0/jobs/259/steps
- https://app.circleci.com/pipelines/github/oliver-charlesworth/nespot/257/workflows/f8c4de4f-2fad-4fac-82fc-fe34a0ffe1ca/jobs/257