### PR TITLE
Optimise PPU

### DIFF
--- a/src/main/kotlin/choliver/nespot/mappers/NromMapper.kt
+++ b/src/main/kotlin/choliver/nespot/mappers/NromMapper.kt
@@ -32,7 +32,7 @@ class NromMapper(private val rom: Rom) : Mapper {
     val mirroredRam = MirroringMemory(rom.mirroring, vram)
 
     override fun get(addr: Address) = when {
-      addr >= BASE_VRAM -> mirroredRam[addr]    // This maps everything >= 0x4000 too
+      (addr >= BASE_VRAM) -> mirroredRam[addr]    // This maps everything >= 0x4000 too
       usingChrRam -> chrRam[addr]
       else -> rom.chrData[addr].data()
     }

--- a/src/main/kotlin/choliver/nespot/ppu/Ppu.kt
+++ b/src/main/kotlin/choliver/nespot/ppu/Ppu.kt
@@ -97,7 +97,7 @@ class Ppu(
     if (bgEnabled || sprEnabled) {
       coords.xFine = coordsBacking.xFine
       coords.xCoarse = coordsBacking.xCoarse
-      coords.xNametable = coordsBacking.xNametable
+      coords.nametable = (coords.nametable and 0b10) or (coordsBacking.nametable and 0b01)
       coords.incrementY()
     }
   }
@@ -142,8 +142,7 @@ class Ppu(
       addr = addr(lo = addr.lo(), hi = data and 0b00111111)
       with(coordsBacking) {
         yCoarse = ((data and 0b00000011) shl 3) or (yCoarse and 0b00111)
-        xNametable = (data and 0b00000100) shr 2
-        yNametable = (data and 0b00001000) shr 3
+        nametable = (data and 0b00001100) shr 2
         yFine = (data and 0b00110000) shr 4  // Lose the top bit
       }
     } else {
@@ -196,10 +195,7 @@ class Ppu(
     largeSprites = data.isBitSet(5)
     // TODO - is master/slave important?
     vblEnabled = data.isBitSet(7)
-    with(coordsBacking) {
-      xNametable = data and 0x01
-      yNametable = (data and 0x02) shr 1
-    }
+    coordsBacking.nametable = data and 0b11
   }
 
   private fun State.writeCtrl2(data: Data) {

--- a/src/main/kotlin/choliver/nespot/ppu/model/Coords.kt
+++ b/src/main/kotlin/choliver/nespot/ppu/model/Coords.kt
@@ -7,10 +7,9 @@ import choliver.nespot.ppu.TILE_SIZE
 
 @MutableForPerfReasons
 data class Coords(
-  var xNametable: Int = 0,    // 0 or 1
+  var nametable: Int = 0,     // 0 to 3 inc.
   var xCoarse: Int = 0,       // 0 to 31 inc.
   var xFine: Int = 0,         // 0 to 7 inc.
-  var yNametable: Int = 0,    // 0 or 1
   var yCoarse: Int = 0,       // 0 to 31 inc.
   var yFine: Int = 0          // 0 to 7 inc.
 ) {
@@ -23,7 +22,7 @@ data class Coords(
         when (xCoarse) {
           (NUM_TILE_COLUMNS - 1) -> {
             xCoarse = 0
-            xNametable = 1 - xNametable   // Wraparound
+            nametable = nametable xor 1   // Wraparound
           }
           else -> xCoarse++
         }
@@ -40,7 +39,7 @@ data class Coords(
         when (yCoarse) {
           (NUM_TILE_ROWS - 1) -> {
             yCoarse = 0
-            yNametable = 1 - yNametable   // Wraparound
+            nametable = nametable xor 2   // Wraparound
           }
           (NUM_TILE_COLUMNS - 1) -> yCoarse = 0   // Weird special case
           else -> yCoarse++

--- a/src/test/kotlin/choliver/nespot/ppu/CoordsTest.kt
+++ b/src/test/kotlin/choliver/nespot/ppu/CoordsTest.kt
@@ -16,12 +16,12 @@ class CoordsTest {
       Coords(xCoarse = 0, xFine = 7).incrementX()
     )
     assertEquals(
-      Coords(xNametable = 1, xCoarse = 0, xFine = 0),
-      Coords(xNametable = 0, xCoarse = 31, xFine = 7).incrementX()
+      Coords(nametable = 1, xCoarse = 0, xFine = 0),
+      Coords(nametable = 0, xCoarse = 31, xFine = 7).incrementX()
     )
     assertEquals(
-      Coords(xNametable = 0, xCoarse = 0, xFine = 0),
-      Coords(xNametable = 1, xCoarse = 31, xFine = 7).incrementX()
+      Coords(nametable = 0, xCoarse = 0, xFine = 0),
+      Coords(nametable = 1, xCoarse = 31, xFine = 7).incrementX()
     )
   }
 
@@ -36,12 +36,12 @@ class CoordsTest {
       Coords(yCoarse = 0, yFine = 7).incrementY()
     )
     assertEquals(
-      Coords(yNametable = 1, yCoarse = 0, yFine = 0),
-      Coords(yNametable = 0, yCoarse = 29, yFine = 7).incrementY()
+      Coords(nametable = 2, yCoarse = 0, yFine = 0),
+      Coords(nametable = 0, yCoarse = 29, yFine = 7).incrementY()
     )
     assertEquals(
-      Coords(yNametable = 0, yCoarse = 0, yFine = 0),
-      Coords(yNametable = 1, yCoarse = 29, yFine = 7).incrementY()
+      Coords(nametable = 0, yCoarse = 0, yFine = 0),
+      Coords(nametable = 2, yCoarse = 29, yFine = 7).incrementY()
     )
     // Some weird special cases
     assertEquals(

--- a/src/test/kotlin/choliver/nespot/ppu/PpuTest.kt
+++ b/src/test/kotlin/choliver/nespot/ppu/PpuTest.kt
@@ -353,10 +353,7 @@ class PpuTest {
       advanceToNextFrameAndResetMock()
       advancePastAction()
 
-      with(captureContext().coords) {
-        assertEquals((idx and 2) shr 1, yNametable)
-        assertEquals(idx and 1, xNametable)
-      }
+      assertEquals(idx, captureContext().coords.nametable)
     }
 
     @Test
@@ -434,9 +431,8 @@ class PpuTest {
       advanceScanlines(1)
 
       val ctx = captureContext()
-      assertEquals(1, ctx.coords.xNametable)
+      assertEquals(0b11, ctx.coords.nametable)
       assertEquals(0b10101, ctx.coords.xCoarse)
-      assertEquals(1, ctx.coords.yNametable)
       assertEquals(0b11111, ctx.coords.yCoarse)
       assertEquals(0b010 + 1, ctx.coords.yFine)  // This gets incremented
     }


### PR DESCRIPTION
1. Merge `xNametable` and `yNametable` into single entry.
2. Pre-compute colour lookup table (32 memory operations per scanline rather than 256).
3. Minimise conditionals in `loadAndRenderBackground` for BG disabled or clipped.