### PR TITLE
Optimise everything

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,5 @@
 import org.gradle.api.tasks.testing.logging.TestLogEvent.FAILED
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
   application
@@ -24,6 +25,11 @@ dependencies {
 javafx {
   version = "14"
   modules = listOf("javafx.graphics")
+}
+
+// We don't need checkParameterIsNotNull (etc.) as we don't interact with Java code
+tasks.withType<KotlinCompile>().configureEach {
+  kotlinOptions.freeCompilerArgs += listOf("-Xno-param-assertions", "-Xno-call-assertions", "-Xno-receiver-assertions")
 }
 
 tasks.test {

--- a/src/main/kotlin/choliver/nespot/DelegateUtils.kt
+++ b/src/main/kotlin/choliver/nespot/DelegateUtils.kt
@@ -1,6 +1,0 @@
-package choliver.nespot
-
-import kotlin.properties.Delegates.observable
-
-internal inline fun <T> observable(initialValue: T, crossinline onChange: (newValue: T) -> Unit) =
-  observable(initialValue) { _, _, newValue -> onChange(newValue) }

--- a/src/main/kotlin/choliver/nespot/apu/DmcSynth.kt
+++ b/src/main/kotlin/choliver/nespot/apu/DmcSynth.kt
@@ -3,7 +3,6 @@ package choliver.nespot.apu
 import choliver.nespot.Address
 import choliver.nespot.Data
 import choliver.nespot.Memory
-import choliver.nespot.observable
 import java.lang.Integer.max
 import java.lang.Integer.min
 
@@ -16,19 +15,25 @@ class DmcSynth(private val memory: Memory) : Synth {
   private var sample: Data = 0
   private var _irq = false
 
-  var irqEnabled by observable(false) { if (!it) _irq = false }
+  var irqEnabled = false
+    set(value) {
+      field = value
+      if (!value) _irq = false
+    }
   var loop = false
   var level: Data = 0
   var address: Address = 0x0000
   var length = 0
 
-  override var enabled by observable(false) {
-    when {
-      (it && (numBytesRemaining == 0)) -> restart()
-      !it -> clear()
+  override var enabled = false
+    set(value) {
+      field = value
+      when {
+        (value && (numBytesRemaining == 0)) -> restart()
+        !value -> clear()
+      }
+      _irq = false
     }
-    _irq = false
-  }
   override val hasRemainingOutput get() = numBytesRemaining > 0
   override val output get() = level
 

--- a/src/main/kotlin/choliver/nespot/apu/FrameSequencer.kt
+++ b/src/main/kotlin/choliver/nespot/apu/FrameSequencer.kt
@@ -6,7 +6,6 @@ import choliver.nespot.apu.FrameSequencer.Mode.FIVE_STEP
 import choliver.nespot.apu.FrameSequencer.Mode.FOUR_STEP
 import choliver.nespot.cpu.utils._0
 import choliver.nespot.cpu.utils._1
-import choliver.nespot.observable
 
 // TODO - interrupts
 class FrameSequencer(
@@ -33,15 +32,17 @@ class FrameSequencer(
   private var iSeq = 0
   private var justReset = false
 
-  var mode by observable(FOUR_STEP) {
-    timer.periodCycles = when (it) {
-      FOUR_STEP -> fourStepPeriod
-      FIVE_STEP -> fiveStepPeriod
+  var mode = FOUR_STEP
+    set(value) {
+      field = value
+      timer.periodCycles = when (value) {
+        FOUR_STEP -> fourStepPeriod
+        FIVE_STEP -> fiveStepPeriod
+      }
+      timer.restart()
+      iSeq = 0
+      justReset = true
     }
-    timer.restart()
-    iSeq = 0
-    justReset = true
-  }
 
   fun take(): Ticks {
     val ret = if (timer.take() == 1) {

--- a/src/main/kotlin/choliver/nespot/apu/NoiseSynth.kt
+++ b/src/main/kotlin/choliver/nespot/apu/NoiseSynth.kt
@@ -1,5 +1,7 @@
 package choliver.nespot.apu
 
+import choliver.nespot.isBitSet
+
 // http://wiki.nesdev.com/w/index.php/APU_Noise
 class NoiseSynth : Synth {
   private val lc = LengthCounter()
@@ -20,9 +22,11 @@ class NoiseSynth : Synth {
   var mode = 0
 
   override fun onTimer(num: Int) {
-    for (i in 0 until num) {
-      val fb = (sr and 0x01) xor ((if (mode == 0) (sr shr 1) else (sr shr 6)) and 0x01)
-      sr = (sr shr 1) or (fb shl 14)
+    // No point running this faster than 1 tick per sample, so run at most once
+    if (num > 0) {
+      val tap = if (mode == 0) 1 else 6
+      val fb = (sr xor (sr shr tap)).isBitSet(0)
+      sr = (sr shr 1) or (if (fb) (1 shl 14) else 0)
     }
   }
 

--- a/src/main/kotlin/choliver/nespot/apu/Timer.kt
+++ b/src/main/kotlin/choliver/nespot/apu/Timer.kt
@@ -2,7 +2,6 @@ package choliver.nespot.apu
 
 import choliver.nespot.CYCLES_PER_SAMPLE
 import choliver.nespot.Rational
-import choliver.nespot.observable
 import kotlin.math.max
 
 class Timer(
@@ -10,7 +9,11 @@ class Timer(
 ) {
   private var pos = 0
   private var jump = cyclesPerSample.b
-  var periodCycles by observable(1) { jump = it * cyclesPerSample.b }
+  var periodCycles = 1
+    set(value) {
+      field = value
+      jump = value * cyclesPerSample.b
+    }
 
   fun take(): Int {
     pos -= cyclesPerSample.a

--- a/src/main/kotlin/choliver/nespot/cartridge/MirroringMemory.kt
+++ b/src/main/kotlin/choliver/nespot/cartridge/MirroringMemory.kt
@@ -6,20 +6,20 @@ import choliver.nespot.Memory
 import choliver.nespot.cartridge.Rom.Mirroring
 import choliver.nespot.cartridge.Rom.Mirroring.*
 
-class MirroringMemory(
-  mirroring: Mirroring,
+internal class MirroringMemory(
+  private val mirroring: Mirroring,
   private val ram: Memory
 ) : Memory {
-  private val mapToVram: (Address) -> Address = when (mirroring) {
-    HORIZONTAL -> ::mirrorHorizontal
-    VERTICAL -> ::mirrorVertical
-    IGNORED -> throw UnsupportedOperationException()
-  }
-
   override fun get(addr: Address) = ram[mapToVram(addr)]
 
   override fun set(addr: Address, data: Data) {
     ram[mapToVram(addr)] = data
+  }
+
+  private fun mapToVram(addr: Address) = when (mirroring) {
+    HORIZONTAL -> mirrorHorizontal(addr)
+    VERTICAL -> mirrorVertical(addr)
+    IGNORED -> throw UnsupportedOperationException()
   }
 }
 

--- a/src/main/kotlin/choliver/nespot/cpu/Cpu.kt
+++ b/src/main/kotlin/choliver/nespot/cpu/Cpu.kt
@@ -42,7 +42,7 @@ class Cpu(
     return diagnostics.nextStepOverride ?: when {
       (flags and INTERRUPT_RESET != 0) -> RESET
       (flags and INTERRUPT_NMI != 0) && !state.prevNmi -> NMI
-      (flags and FLAG_IRQ != 0) && !state.regs.p.i -> IRQ
+      (flags and INTERRUPT_IRQ != 0) && !state.regs.p.i -> IRQ
       else -> INSTRUCTION
     }
   }
@@ -316,7 +316,7 @@ class Cpu(
   companion object {
     const val INTERRUPT_RESET = 0x01
     const val INTERRUPT_NMI = 0x02
-    const val FLAG_IRQ = 0x04
+    const val INTERRUPT_IRQ = 0x04
 
     const val VECTOR_NMI: Address = 0xFFFA
     const val VECTOR_RESET: Address = 0xFFFC

--- a/src/main/kotlin/choliver/nespot/cpu/Cpu.kt
+++ b/src/main/kotlin/choliver/nespot/cpu/Cpu.kt
@@ -6,6 +6,7 @@ import choliver.nespot.cpu.InstructionDecoder.Decoded
 import choliver.nespot.cpu.model.AddressMode.ACCUMULATOR
 import choliver.nespot.cpu.model.AddressMode.IMMEDIATE
 import choliver.nespot.cpu.model.Opcode.*
+import choliver.nespot.cpu.model.Regs
 import choliver.nespot.cpu.model.State
 import choliver.nespot.cpu.model.toFlags
 import choliver.nespot.cpu.utils._0
@@ -45,7 +46,7 @@ class Cpu(
   }
 
   private fun vector(addr: Address, updateStack: Boolean, disableIrq: Boolean): Int {
-    interrupt(addr, updateStack = updateStack, setBreakFlag = false)
+    state.regs.interrupt(addr, updateStack = updateStack, setBreakFlag = false)
     state.regs.p.i = state.regs.p.i || disableIrq
     return NUM_INTERRUPT_CYCLES
   }
@@ -54,189 +55,187 @@ class Cpu(
     decoder.decode(decoded, pc = state.regs.pc, x = state.regs.x, y = state.regs.y)
     state.regs.pc = decoded.nextPc
     extraCycles = 0
-    execute()
+    state.regs.execute()
     return decoded.numCycles + extraCycles
   }
 
-  private fun execute() {
-    state.regs.apply {
-      when (decoded.opcode) {
-        ADC -> add(resolve())
-        SBC -> add(resolve() xor 0xFF)
+  private fun Regs.execute() {
+    when (decoded.opcode) {
+      ADC -> add(resolve())
+      SBC -> add(resolve() xor 0xFF)
 
-        CMP -> compare(a, resolve())
-        CPX -> compare(x, resolve())
-        CPY -> compare(y, resolve())
+      CMP -> compare(a, resolve())
+      CPX -> compare(x, resolve())
+      CPY -> compare(y, resolve())
 
-        DEC -> storeResult(resolve() - 1)
-        DEX -> {
-          x = (x - 1).data()
-          updateZN(x)
-        }
-        DEY -> {
-          y = (y - 1).data()
-          updateZN(y)
-        }
-
-        INC -> storeResult(resolve() + 1)
-        INX -> {
-          x = (x + 1).data()
-          updateZN(x)
-        }
-        INY -> {
-          y = (y + 1).data()
-          updateZN(y)
-        }
-
-        ASL -> {
-          val data = resolve()
-          storeResult(data shl 1)
-          p.c = data.isBitSet(7)
-        }
-        LSR -> {
-          val data = resolve()
-          storeResult(data shr 1)
-          p.c = data.isBitSet(0)
-        }
-        ROL -> {
-          val data = resolve()
-          storeResult((data shl 1) or (if (p.c) 1 else 0))
-          p.c = data.isBitSet(7)
-        }
-        ROR -> {
-          val data = resolve()
-          storeResult((data shr 1) or (if (p.c) 0x80 else 0))
-          p.c = data.isBitSet(0)
-        }
-
-        AND -> {
-          a = a and resolve()
-          updateZN(a)
-        }
-        ORA -> {
-          a = a or resolve()
-          updateZN(a)
-        }
-        EOR -> {
-          a = a xor resolve()
-          updateZN(a)
-        }
-
-        BIT -> {
-          val data = resolve()
-          p.z = (a and data).isZero()
-          p.n = data.isNeg()
-          p.v = data.isBitSet(6)
-        }
-
-        LDA -> {
-          a = resolve()
-          updateZN(a)
-        }
-        LDX -> {
-          x = resolve()
-          updateZN(x)
-        }
-        LDY -> {
-          y = resolve()
-          updateZN(y)
-        }
-
-        STA -> memory[decoded.addr] = a
-        STX -> memory[decoded.addr] = x
-        STY -> memory[decoded.addr] = y
-
-        PHP -> push(p.data() or 0x10)  // Most online references state that PHP also sets B on stack
-        PHA -> push(a)
-        PLP -> p = pop().toFlags()
-        PLA -> {
-          a = pop()
-          updateZN(a)
-        }
-
-        JMP -> pc = decoded.addr
-
-        JSR -> {
-          // One before next instruction (note we already advanced PC)
-          push((pc - 1).hi())
-          push((pc - 1).lo())
-          pc = decoded.addr
-        }
-
-        RTS -> pc = (addr(lo = pop(), hi = pop()) + 1).addr()
-
-        RTI -> {
-          p = pop().toFlags()
-          pc = addr(lo = pop(), hi = pop())
-        }
-
-        BRK -> interrupt(VECTOR_IRQ, updateStack = true, setBreakFlag = true)
-
-        BPL -> branch(!p.n)
-        BMI -> branch(p.n)
-        BVC -> branch(!p.v)
-        BVS -> branch(p.v)
-        BCC -> branch(!p.c)
-        BCS -> branch(p.c)
-        BNE -> branch(!p.z)
-        BEQ -> branch(p.z)
-
-        TXA -> {
-          a = x
-          updateZN(a)
-        }
-        TYA -> {
-          a = y
-          updateZN(a)
-        }
-        TXS -> s = x
-        TAY -> {
-          y = a
-          updateZN(y)
-        }
-        TAX -> {
-          x = a
-          updateZN(x)
-        }
-        TSX -> {
-          x = s
-          updateZN(x)
-        }
-
-        CLC -> p.c = _0
-        CLD -> p.d = _0
-        CLI -> p.i = _0
-        CLV -> p.v = _0
-        SEC -> p.c = _1
-        SED -> p.d = _1
-        SEI -> p.i = _1
-
-        NOP -> { }
+      DEC -> storeResult(resolve() - 1)
+      DEX -> {
+        x = (x - 1).data()
+        updateZN(x)
       }
+      DEY -> {
+        y = (y - 1).data()
+        updateZN(y)
+      }
+
+      INC -> storeResult(resolve() + 1)
+      INX -> {
+        x = (x + 1).data()
+        updateZN(x)
+      }
+      INY -> {
+        y = (y + 1).data()
+        updateZN(y)
+      }
+
+      ASL -> {
+        val data = resolve()
+        storeResult(data shl 1)
+        p.c = data.isBitSet(7)
+      }
+      LSR -> {
+        val data = resolve()
+        storeResult(data shr 1)
+        p.c = data.isBitSet(0)
+      }
+      ROL -> {
+        val data = resolve()
+        storeResult((data shl 1) or (if (p.c) 1 else 0))
+        p.c = data.isBitSet(7)
+      }
+      ROR -> {
+        val data = resolve()
+        storeResult((data shr 1) or (if (p.c) 0x80 else 0))
+        p.c = data.isBitSet(0)
+      }
+
+      AND -> {
+        a = a and resolve()
+        updateZN(a)
+      }
+      ORA -> {
+        a = a or resolve()
+        updateZN(a)
+      }
+      EOR -> {
+        a = a xor resolve()
+        updateZN(a)
+      }
+
+      BIT -> {
+        val data = resolve()
+        p.z = (a and data).isZero()
+        p.n = data.isNeg()
+        p.v = data.isBitSet(6)
+      }
+
+      LDA -> {
+        a = resolve()
+        updateZN(a)
+      }
+      LDX -> {
+        x = resolve()
+        updateZN(x)
+      }
+      LDY -> {
+        y = resolve()
+        updateZN(y)
+      }
+
+      STA -> memory[decoded.addr] = a
+      STX -> memory[decoded.addr] = x
+      STY -> memory[decoded.addr] = y
+
+      PHP -> push(p.data() or 0x10)  // Most online references state that PHP also sets B on stack
+      PHA -> push(a)
+      PLP -> p = pop().toFlags()
+      PLA -> {
+        a = pop()
+        updateZN(a)
+      }
+
+      JMP -> pc = decoded.addr
+
+      JSR -> {
+        // One before next instruction (note we already advanced PC)
+        push((pc - 1).hi())
+        push((pc - 1).lo())
+        pc = decoded.addr
+      }
+
+      RTS -> pc = (addr(lo = pop(), hi = pop()) + 1).addr()
+
+      RTI -> {
+        p = pop().toFlags()
+        pc = addr(lo = pop(), hi = pop())
+      }
+
+      BRK -> interrupt(VECTOR_IRQ, updateStack = true, setBreakFlag = true)
+
+      BPL -> branch(!p.n)
+      BMI -> branch(p.n)
+      BVC -> branch(!p.v)
+      BVS -> branch(p.v)
+      BCC -> branch(!p.c)
+      BCS -> branch(p.c)
+      BNE -> branch(!p.z)
+      BEQ -> branch(p.z)
+
+      TXA -> {
+        a = x
+        updateZN(a)
+      }
+      TYA -> {
+        a = y
+        updateZN(a)
+      }
+      TXS -> s = x
+      TAY -> {
+        y = a
+        updateZN(y)
+      }
+      TAX -> {
+        x = a
+        updateZN(x)
+      }
+      TSX -> {
+        x = s
+        updateZN(x)
+      }
+
+      CLC -> p.c = _0
+      CLD -> p.d = _0
+      CLI -> p.i = _0
+      CLV -> p.v = _0
+      SEC -> p.c = _1
+      SED -> p.d = _1
+      SEI -> p.i = _1
+
+      NOP -> { }
     }
   }
 
-  private fun branch(cond: Boolean) {
+  private fun Regs.branch(cond: Boolean) {
     if (cond) {
       extraCycles++
-      if (((state.regs.pc xor decoded.addr) and 0xFF00) != 0) {
+      if (((pc xor decoded.addr) and 0xFF00) != 0) {
         extraCycles++   // Page change
       }
-      state.regs.pc = decoded.addr
+      pc = decoded.addr
     }
   }
 
-  private fun push(data: Data) {
-    memory[state.regs.s or 0x100] = data
-    state.regs.s = (state.regs.s - 1).data()
+  private fun Regs.push(data: Data) {
+    memory[s or 0x100] = data
+    s = (s - 1).data()
   }
 
-  private fun pop(): Data {
-    state.regs.s = (state.regs.s + 1).data()
-    return memory[state.regs.s or 0x100]
+  private fun Regs.pop(): Data {
+    s = (s + 1).data()
+    return memory[s or 0x100]
   }
 
-  private fun add(rhs: Data) = state.regs.apply {
+  private fun Regs.add(rhs: Data) {
     val c = p.c
     val raw = a + rhs + (if (c) 1 else 0)
     val result = raw.data()
@@ -249,7 +248,7 @@ class Cpu(
     updateZN(result)
   }
 
-  private fun compare(lhs: Data, rhs: Data) = state.regs.apply {
+  private fun Regs.compare(lhs: Data, rhs: Data) {
     val raw = (lhs + (rhs xor 0xFF) + 1)
     val result = raw.data()
 
@@ -257,7 +256,7 @@ class Cpu(
     updateZN(result)
   }
 
-  private fun interrupt(vector: Address, updateStack: Boolean, setBreakFlag: Boolean) = state.regs.apply {
+  private fun Regs.interrupt(vector: Address, updateStack: Boolean, setBreakFlag: Boolean) {
     if (updateStack) {
       push(pc.hi())
       push(pc.lo())
@@ -276,19 +275,19 @@ class Cpu(
     else -> memory[decoded.addr]
   }
 
-  private fun storeResult(data: Data) {
+  private fun Regs.storeResult(data: Data) {
     val d = data.data()
     if (decoded.addressMode == ACCUMULATOR) {
-      state.regs.a = d
+      a = d
     } else {
       memory[decoded.addr] = d
     }
     updateZN(d)
   }
 
-  private fun updateZN(data: Data) {
-    state.regs.p.z = data.isZero()
-    state.regs.p.n = data.isNeg()
+  private fun Regs.updateZN(data: Data) {
+    p.z = data.isZero()
+    p.n = data.isNeg()
   }
 
   enum class NextStep {

--- a/src/main/kotlin/choliver/nespot/mappers/NromMapper.kt
+++ b/src/main/kotlin/choliver/nespot/mappers/NromMapper.kt
@@ -35,19 +35,6 @@ class NromMapper(private val rom: Rom) : Mapper {
       object : Memory {
         override fun get(addr: Address) = when {
           (addr >= BASE_VRAM) -> mirroredRam[addr]    // This maps everything >= 0x4000 too
-          else -> rom.chrData[addr].data()
-        }
-
-        override fun set(addr: Address, data: Data) {
-          when {
-            (addr >= BASE_VRAM) -> mirroredRam[addr] = data   // This maps everything >= 0x4000 too
-          }
-        }
-      }
-    } else {
-      object : Memory {
-        override fun get(addr: Address) = when {
-          (addr >= BASE_VRAM) -> mirroredRam[addr]    // This maps everything >= 0x4000 too
           else -> chrRam[addr]
         }
 
@@ -55,6 +42,19 @@ class NromMapper(private val rom: Rom) : Mapper {
           when {
             (addr >= BASE_VRAM) -> mirroredRam[addr] = data   // This maps everything >= 0x4000 too
             else -> chrRam[addr] = data
+          }
+        }
+      }
+    } else {
+      object : Memory {
+        override fun get(addr: Address) = when {
+          (addr >= BASE_VRAM) -> mirroredRam[addr]    // This maps everything >= 0x4000 too
+          else -> rom.chrData[addr].data()
+        }
+
+        override fun set(addr: Address, data: Data) {
+          when {
+            (addr >= BASE_VRAM) -> mirroredRam[addr] = data   // This maps everything >= 0x4000 too
           }
         }
       }

--- a/src/main/kotlin/choliver/nespot/mappers/NromMapper.kt
+++ b/src/main/kotlin/choliver/nespot/mappers/NromMapper.kt
@@ -28,19 +28,35 @@ class NromMapper(private val rom: Rom) : Mapper {
     }
   }
 
-  override fun chr(vram: Memory) = object : Memory {
+  override fun chr(vram: Memory): Memory {
     val mirroredRam = MirroringMemory(rom.mirroring, vram)
 
-    override fun get(addr: Address) = when {
-      (addr >= BASE_VRAM) -> mirroredRam[addr]    // This maps everything >= 0x4000 too
-      usingChrRam -> chrRam[addr]
-      else -> rom.chrData[addr].data()
-    }
+    return if (usingChrRam) {
+      object : Memory {
+        override fun get(addr: Address) = when {
+          (addr >= BASE_VRAM) -> mirroredRam[addr]    // This maps everything >= 0x4000 too
+          else -> rom.chrData[addr].data()
+        }
 
-    override fun set(addr: Address, data: Data) {
-      when {
-        (addr >= BASE_VRAM) -> mirroredRam[addr] = data   // This maps everything >= 0x4000 too
-        usingChrRam -> chrRam[addr] = data
+        override fun set(addr: Address, data: Data) {
+          when {
+            (addr >= BASE_VRAM) -> mirroredRam[addr] = data   // This maps everything >= 0x4000 too
+          }
+        }
+      }
+    } else {
+      object : Memory {
+        override fun get(addr: Address) = when {
+          (addr >= BASE_VRAM) -> mirroredRam[addr]    // This maps everything >= 0x4000 too
+          else -> chrRam[addr]
+        }
+
+        override fun set(addr: Address, data: Data) {
+          when {
+            (addr >= BASE_VRAM) -> mirroredRam[addr] = data   // This maps everything >= 0x4000 too
+            else -> chrRam[addr] = data
+          }
+        }
       }
     }
   }

--- a/src/main/kotlin/choliver/nespot/nes/CpuMapper.kt
+++ b/src/main/kotlin/choliver/nespot/nes/CpuMapper.kt
@@ -21,12 +21,13 @@ class CpuMapper(
   private val joypads: Joypads
 ) : Memory {
   override fun get(addr: Address) = when {
+    addr >= 0x4020 -> prg[addr]
     addr < 0x2000 -> ram[addr % 2048]
     addr < 0x4000 -> ppu.readReg(addr % 8)
     addr == ADDR_JOYPAD1 -> joypads.read1()
     addr == ADDR_JOYPAD2 -> joypads.read2()
     addr == ADDR_APU_STATUS -> apu.readStatus()
-    else -> prg[addr]
+    else -> throw RuntimeException()   // Should never happen
   }
 
   override fun set(addr: Address, data: Data) = when {

--- a/src/main/kotlin/choliver/nespot/nes/Nes.kt
+++ b/src/main/kotlin/choliver/nespot/nes/Nes.kt
@@ -8,7 +8,7 @@ import choliver.nespot.apu.Apu
 import choliver.nespot.cartridge.Rom
 import choliver.nespot.cartridge.createMapper
 import choliver.nespot.cpu.Cpu
-import choliver.nespot.cpu.Cpu.Companion.FLAG_IRQ
+import choliver.nespot.cpu.Cpu.Companion.INTERRUPT_IRQ
 import choliver.nespot.cpu.Cpu.Companion.INTERRUPT_NMI
 import choliver.nespot.ppu.Ppu
 import java.nio.IntBuffer
@@ -56,7 +56,7 @@ class Nes(
     ppu.advance(cycles)
   }
 
-  private fun pollInterrupts() = (if (apu.irq || mapper.irq) FLAG_IRQ else 0) or (if (ppu.vbl) INTERRUPT_NMI else 0)
+  private fun pollInterrupts() = (if (apu.irq || mapper.irq) INTERRUPT_IRQ else 0) or (if (ppu.vbl) INTERRUPT_NMI else 0)
 
   private fun maybeIntercept(memory: Memory) = if (onStore != null) {
     object : Memory {

--- a/src/main/kotlin/choliver/nespot/ppu/Ppu.kt
+++ b/src/main/kotlin/choliver/nespot/ppu/Ppu.kt
@@ -47,9 +47,12 @@ class Ppu(
   }
 
   private fun State.incrementFramePos() {
-    dot = (dot + 1) % DOTS_PER_SCANLINE
-    if (dot == 0) {
-      scanline = (scanline + 1) % SCANLINES_PER_FRAME
+    when (dot) {
+      (DOTS_PER_SCANLINE - 1) -> {
+        dot = 0
+        scanline = (scanline + 1) % SCANLINES_PER_FRAME
+      }
+      else -> dot++
     }
   }
 

--- a/src/main/kotlin/choliver/nespot/ppu/Renderer.kt
+++ b/src/main/kotlin/choliver/nespot/ppu/Renderer.kt
@@ -38,6 +38,7 @@ class Renderer(
 
   // Don't persist beyond internal call, so need to be in State
   private val opaqueSpr = MutableList(SCREEN_WIDTH) { false }  // Identifies opaque sprite pixels
+  private val colorLookup = IntArray(32) { 0 }
   private var iPalette = 0
   private var patternLo: Data = 0x00
   private var patternHi: Data = 0x00
@@ -207,10 +208,13 @@ class Renderer(
 
   fun commitToBuffer(ppu: PpuState, buffer: IntBuffer) {
     val mask = if (ppu.greyscale) 0x30 else 0x3F  // TODO - implement greyscale in Palette itself
-    val lookup = IntArray(32) { colors[palette[it] and mask] }  // Optimisation
+    for (i in 0 until 32) {
+      val idx = if (i % 4 == 0) 0 else i
+      colorLookup[i] = colors[palette[i]] and mask
+    }
 
     buffer.position(ppu.scanline * SCREEN_WIDTH)
-    state.paletteIndices.forEach { buffer.put(lookup[it]) }
+    state.paletteIndices.forEach { buffer.put(colorLookup[it]) }
   }
 
   private fun maybeFlip(v: Int, flip: Boolean) = if (flip) (7 - v) else v

--- a/src/main/kotlin/choliver/nespot/ppu/Renderer.kt
+++ b/src/main/kotlin/choliver/nespot/ppu/Renderer.kt
@@ -79,40 +79,17 @@ class Renderer(
     }
     loadNextBackgroundTile()
 
-    // Do as many fully-aligned tiles as possible (reverse through each tile because of pattern order)
+    // Do as many fully-aligned tiles as possible (reverse through each tile because of pattern packing order)
     repeat(NUM_TILE_COLUMNS - 2) {
-      indices[x + 7] = paletteBase or (patternLo and 1) or ((patternHi and 1) shl 1)
-      patternLo = patternLo shr 1
-      patternHi = patternHi shr 1
-
-      indices[x + 6] = paletteBase or (patternLo and 1) or ((patternHi and 1) shl 1)
-      patternLo = patternLo shr 1
-      patternHi = patternHi shr 1
-
-      indices[x + 5] = paletteBase or (patternLo and 1) or ((patternHi and 1) shl 1)
-      patternLo = patternLo shr 1
-      patternHi = patternHi shr 1
-
-      indices[x + 4] = paletteBase or (patternLo and 1) or ((patternHi and 1) shl 1)
-      patternLo = patternLo shr 1
-      patternHi = patternHi shr 1
-
-      indices[x + 3] = paletteBase or (patternLo and 1) or ((patternHi and 1) shl 1)
-      patternLo = patternLo shr 1
-      patternHi = patternHi shr 1
-
-      indices[x + 2] = paletteBase or (patternLo and 1) or ((patternHi and 1) shl 1)
-      patternLo = patternLo shr 1
-      patternHi = patternHi shr 1
-
-      indices[x + 1] = paletteBase or (patternLo and 1) or ((patternHi and 1) shl 1)
-      patternLo = patternLo shr 1
-      patternHi = patternHi shr 1
-
-      indices[x + 0] = paletteBase or (patternLo and 1) or ((patternHi and 1) shl 1)
-      patternLo = patternLo shr 1
-      patternHi = patternHi shr 1
-
+      patternHi = patternHi shl 1
+      indices[x + 7] = paletteBase or ((patternLo shr 0) and 1) or ((patternHi shr 0) and 2)
+      indices[x + 6] = paletteBase or ((patternLo shr 1) and 1) or ((patternHi shr 1) and 2)
+      indices[x + 5] = paletteBase or ((patternLo shr 2) and 1) or ((patternHi shr 2) and 2)
+      indices[x + 4] = paletteBase or ((patternLo shr 3) and 1) or ((patternHi shr 3) and 2)
+      indices[x + 3] = paletteBase or ((patternLo shr 4) and 1) or ((patternHi shr 4) and 2)
+      indices[x + 2] = paletteBase or ((patternLo shr 5) and 1) or ((patternHi shr 5) and 2)
+      indices[x + 1] = paletteBase or ((patternLo shr 6) and 1) or ((patternHi shr 6) and 2)
+      indices[x + 0] = paletteBase or ((patternLo shr 7) and 1) or ((patternHi shr 7) and 2)
       coords.incrementXByTile()
       loadNextBackgroundTile()
       x += 8

--- a/src/main/kotlin/choliver/nespot/ppu/Renderer.kt
+++ b/src/main/kotlin/choliver/nespot/ppu/Renderer.kt
@@ -79,18 +79,43 @@ class Renderer(
     }
     loadNextBackgroundTile()
 
-    // Do as many fully-aligned tiles as possible
+    // Do as many fully-aligned tiles as possible (reverse through each tile because of pattern order)
     repeat(NUM_TILE_COLUMNS - 2) {
-      indices[x++] = paletteBase + patternPixel(patternLo, patternHi, 0)
-      indices[x++] = paletteBase + patternPixel(patternLo, patternHi, 1)
-      indices[x++] = paletteBase + patternPixel(patternLo, patternHi, 2)
-      indices[x++] = paletteBase + patternPixel(patternLo, patternHi, 3)
-      indices[x++] = paletteBase + patternPixel(patternLo, patternHi, 4)
-      indices[x++] = paletteBase + patternPixel(patternLo, patternHi, 5)
-      indices[x++] = paletteBase + patternPixel(patternLo, patternHi, 6)
-      indices[x++] = paletteBase + patternPixel(patternLo, patternHi, 7)
+      indices[x + 7] = paletteBase or (patternLo and 1) or ((patternHi and 1) shl 1)
+      patternLo = patternLo shr 1
+      patternHi = patternHi shr 1
+
+      indices[x + 6] = paletteBase or (patternLo and 1) or ((patternHi and 1) shl 1)
+      patternLo = patternLo shr 1
+      patternHi = patternHi shr 1
+
+      indices[x + 5] = paletteBase or (patternLo and 1) or ((patternHi and 1) shl 1)
+      patternLo = patternLo shr 1
+      patternHi = patternHi shr 1
+
+      indices[x + 4] = paletteBase or (patternLo and 1) or ((patternHi and 1) shl 1)
+      patternLo = patternLo shr 1
+      patternHi = patternHi shr 1
+
+      indices[x + 3] = paletteBase or (patternLo and 1) or ((patternHi and 1) shl 1)
+      patternLo = patternLo shr 1
+      patternHi = patternHi shr 1
+
+      indices[x + 2] = paletteBase or (patternLo and 1) or ((patternHi and 1) shl 1)
+      patternLo = patternLo shr 1
+      patternHi = patternHi shr 1
+
+      indices[x + 1] = paletteBase or (patternLo and 1) or ((patternHi and 1) shl 1)
+      patternLo = patternLo shr 1
+      patternHi = patternHi shr 1
+
+      indices[x + 0] = paletteBase or (patternLo and 1) or ((patternHi and 1) shl 1)
+      patternLo = patternLo shr 1
+      patternHi = patternHi shr 1
+
       coords.incrementXByTile()
       loadNextBackgroundTile()
+      x += 8
     }
 
     // Epilogue

--- a/src/main/kotlin/choliver/nespot/ppu/Renderer.kt
+++ b/src/main/kotlin/choliver/nespot/ppu/Renderer.kt
@@ -37,7 +37,7 @@ class Renderer(
   )
 
   // Don't persist beyond internal call, so need to be in State
-  private val opaqueSpr = MutableList(SCREEN_WIDTH) { false }  // Identifies opaque sprite pixels
+  private val anyOpaqueSpr = MutableList(SCREEN_WIDTH) { false }  // Identifies opaque sprite pixels
   private val colorLookup = IntArray(32) { 0 }
   private var iPalette = 0
   private var patternLo: Data = 0x00
@@ -173,7 +173,7 @@ class Renderer(
   // Lowest index is highest priority, so render last
   fun renderSprites(ppu: PpuState) {
     for (x in 0 until SCREEN_WIDTH) {
-      opaqueSpr[x] = false
+      anyOpaqueSpr[x] = false
     }
 
     if (ppu.sprEnabled) {
@@ -189,11 +189,11 @@ class Renderer(
       val x = spr.x + xPixel
       val c = patternPixel(spr.patternLo, spr.patternHi, xPixel xor mask)
 
-      if ((c != 0) && !opaqueSpr[x] && (ppu.sprLeftTileEnabled || (x >= TILE_SIZE))) {
-        opaqueSpr[x] = true
+      if ((c != 0) && !anyOpaqueSpr[x] && (ppu.sprLeftTileEnabled || (x >= TILE_SIZE))) {
+        anyOpaqueSpr[x] = true
 
-        // There is no previous opaque sprite, so if pixel is opaque then it must be background
-        val opaqueBg = (state.paletteIndices[x] != 0)
+        // There is no higher-priority opaque sprite, so if pixel is opaque then it must be background
+        val opaqueBg = (state.paletteIndices[x] % 4) != 0
 
         if (!(spr.behind && opaqueBg)) {
           state.paletteIndices[x] = (spr.palette * 4) + c

--- a/src/main/kotlin/choliver/nespot/ppu/Renderer.kt
+++ b/src/main/kotlin/choliver/nespot/ppu/Renderer.kt
@@ -141,20 +141,19 @@ class Renderer(
       // Scan until we find a matching sprite
       while (!spr.valid && (iCandidate < NUM_SPRITES)) {
         val y = oam[iCandidate * 4 + 0]
-        val iPattern = oam[iCandidate * 4 + 1]
-        val attrs = oam[iCandidate * 4 + 2]
-        val x = oam[iCandidate * 4 + 3]
-
         val iRow = ppu.scanline - y
-        val flipY = attrs.isBitSet(7)
 
-        with(spr) {
-          this.x = x
-          sprite0 = (iCandidate == 0)
-          paletteBase = ((attrs and 0x03) + 4) * NUM_ENTRIES_PER_PALETTE
-          flipX = attrs.isBitSet(6)
-          behind = attrs.isBitSet(5)
-          patternAddr = patternAddr(
+        spr.valid = iRow in 0 until if (ppu.largeSprites) (TILE_SIZE * 2) else TILE_SIZE
+        if (spr.valid) {
+          val iPattern = oam[iCandidate * 4 + 1]
+          val attrs = oam[iCandidate * 4 + 2]
+          val flipY = attrs.isBitSet(7)
+          spr.x = oam[iCandidate * 4 + 3]
+          spr.sprite0 = (iCandidate == 0)
+          spr.paletteBase = ((attrs and 0x03) + 4) * NUM_ENTRIES_PER_PALETTE
+          spr.flipX = attrs.isBitSet(6)
+          spr.behind = attrs.isBitSet(5)
+          spr.patternAddr = patternAddr(
             iTable = when (ppu.largeSprites) {
               true -> iPattern and 0x01
               false -> ppu.sprPatternTable
@@ -165,7 +164,6 @@ class Renderer(
             },
             iRow = maybeFlip(iRow % TILE_SIZE, flipY)
           )
-          valid = iRow in 0 until if (ppu.largeSprites) (TILE_SIZE * 2) else TILE_SIZE
         }
 
         iCandidate++

--- a/src/main/kotlin/choliver/nespot/ppu/model/Coords.kt
+++ b/src/main/kotlin/choliver/nespot/ppu/model/Coords.kt
@@ -19,15 +19,20 @@ data class Coords(
     when (xFine) {
       (TILE_SIZE - 1) -> {
         xFine = 0
-        when (xCoarse) {
-          (NUM_TILE_COLUMNS - 1) -> {
-            xCoarse = 0
-            nametable = nametable xor 1   // Wraparound
-          }
-          else -> xCoarse++
-        }
+        incrementXByTile()
       }
       else -> xFine++
+    }
+    return this
+  }
+
+  fun incrementXByTile(): Coords {
+    when (xCoarse) {
+      (NUM_TILE_COLUMNS - 1) -> {
+        xCoarse = 0
+        nametable = nametable xor 1   // Wraparound
+      }
+      else -> xCoarse++
     }
     return this
   }

--- a/src/main/kotlin/choliver/nespot/runner/Screen.kt
+++ b/src/main/kotlin/choliver/nespot/runner/Screen.kt
@@ -1,6 +1,5 @@
 package choliver.nespot.runner
 
-import choliver.nespot.observable
 import choliver.nespot.ppu.SCREEN_HEIGHT
 import choliver.nespot.ppu.SCREEN_WIDTH
 import choliver.nespot.ppu.TILE_SIZE
@@ -26,7 +25,11 @@ class Screen(
   private val title: String = "NESpot",
   private val onEvent: (e: Event) -> Unit = {}
 ) {
-  var fullScreen by observable(false) { onFxThread { configureStageAndImage() } }
+  var fullScreen = false
+    set(value) {
+      field = value
+      onFxThread { configureStageAndImage() }
+    }
   private var started = false
   private lateinit var stage: Stage
   private lateinit var imageView: ImageView

--- a/src/test/kotlin/choliver/nespot/cpu/InstructionDecoderTest.kt
+++ b/src/test/kotlin/choliver/nespot/cpu/InstructionDecoderTest.kt
@@ -179,7 +179,9 @@ class InstructionDecoderTest {
   ): Decoded {
     val mmap = listOf(instruction).memoryMap(baseAddr)
     mmap.forEach { (addr, data) -> whenever(memory[addr]) doReturn data }
-    return decoder.decode(baseAddr, x, y)
+    val decoded = Decoded()
+    decoder.decode(decoded, baseAddr, x, y)
+    return decoded
   }
 }
 

--- a/src/test/kotlin/choliver/nespot/cpu/Utils.kt
+++ b/src/test/kotlin/choliver/nespot/cpu/Utils.kt
@@ -1,6 +1,9 @@
 package choliver.nespot.cpu
 
 import choliver.nespot.*
+import choliver.nespot.cpu.Cpu.Companion.FLAG_IRQ
+import choliver.nespot.cpu.Cpu.Companion.INTERRUPT_NMI
+import choliver.nespot.cpu.Cpu.Companion.INTERRUPT_RESET
 import choliver.nespot.cpu.model.*
 import choliver.nespot.cpu.model.AddressMode.*
 import choliver.nespot.cpu.model.Operand.*
@@ -139,9 +142,12 @@ fun assertCpuEffects(
 
   val cpu = Cpu(
     memory,
-    pollReset = { pollReset(iStep) },
-    pollNmi = { pollNmi(iStep) },
-    pollIrq = { pollIrq(iStep) }
+    pollInterrupts = {
+      0 +
+        (if (pollReset(iStep)) INTERRUPT_RESET else 0) or
+        (if (pollNmi(iStep)) INTERRUPT_NMI else 0) or
+        (if (pollIrq(iStep)) FLAG_IRQ else 0)
+    }
   )
 
   cpu.diagnostics.state.regs = initRegs.with(pc = BASE_USER)

--- a/src/test/kotlin/choliver/nespot/cpu/Utils.kt
+++ b/src/test/kotlin/choliver/nespot/cpu/Utils.kt
@@ -1,7 +1,7 @@
 package choliver.nespot.cpu
 
 import choliver.nespot.*
-import choliver.nespot.cpu.Cpu.Companion.FLAG_IRQ
+import choliver.nespot.cpu.Cpu.Companion.INTERRUPT_IRQ
 import choliver.nespot.cpu.Cpu.Companion.INTERRUPT_NMI
 import choliver.nespot.cpu.Cpu.Companion.INTERRUPT_RESET
 import choliver.nespot.cpu.model.*
@@ -146,7 +146,7 @@ fun assertCpuEffects(
       0 +
         (if (pollReset(iStep)) INTERRUPT_RESET else 0) or
         (if (pollNmi(iStep)) INTERRUPT_NMI else 0) or
-        (if (pollIrq(iStep)) FLAG_IRQ else 0)
+        (if (pollIrq(iStep)) INTERRUPT_IRQ else 0)
     }
   )
 

--- a/src/test/kotlin/choliver/nespot/ppu/RendererTest.kt
+++ b/src/test/kotlin/choliver/nespot/ppu/RendererTest.kt
@@ -292,7 +292,7 @@ class RendererTest {
 
       evaluate()
 
-      assertEquals(palette + 4, sprites[0].palette) // Sprite palette, so offset by 4
+      assertEquals((palette + 4) * NUM_ENTRIES_PER_PALETTE, sprites[0].paletteBase) // Sprite palette, so offset by 4
     }
 
     @ParameterizedTest
@@ -470,7 +470,7 @@ class RendererTest {
         patternLo = encodePatternLo(pat)
         patternHi = encodePatternHi(pat)
         x = 5
-        palette = 4
+        paletteBase = 4 * NUM_ENTRIES_PER_PALETTE
       }
 
       render()
@@ -484,7 +484,7 @@ class RendererTest {
         patternLo = encodePatternLo(pat)
         patternHi = encodePatternHi(pat)
         x = 5
-        palette = 4
+        paletteBase = 4 * NUM_ENTRIES_PER_PALETTE
         flipX = true
       }
 
@@ -499,7 +499,7 @@ class RendererTest {
         patternLo = encodePatternLo(pat)
         patternHi = encodePatternHi(pat)
         x = 252
-        palette = 4
+        paletteBase = 4 * NUM_ENTRIES_PER_PALETTE
       }
 
       render()
@@ -513,7 +513,7 @@ class RendererTest {
         patternLo = encodePatternLo(pat)
         patternHi = encodePatternHi(pat)
         x = 5
-        palette = 4
+        paletteBase = 4 * NUM_ENTRIES_PER_PALETTE
       }
 
       render(sprEnabled = false)
@@ -527,7 +527,7 @@ class RendererTest {
         patternLo = encodePatternLo(pat)
         patternHi = encodePatternHi(pat)
         x = 5
-        palette = 4
+        paletteBase = 4 * NUM_ENTRIES_PER_PALETTE
       }
 
       render(sprLeftTileEnabled = false)
@@ -669,7 +669,7 @@ class RendererTest {
       with(sprites[iSprite]) {
         patternLo = encodePatternLo(pattern)
         patternHi = encodePatternHi(pattern)
-        this.palette = palette + 4
+        this.paletteBase = (palette + 4) * NUM_ENTRIES_PER_PALETTE
         this.behind = behind
       }
     }
@@ -700,7 +700,7 @@ class RendererTest {
       with(sprites[0]) {
         patternLo = encodePatternLo(pattern)
         patternHi = encodePatternHi(pattern)
-        palette = 4
+        paletteBase = 4
         sprite0 = true
       }
     }

--- a/src/test/kotlin/choliver/nespot/ppu/RendererTest.kt
+++ b/src/test/kotlin/choliver/nespot/ppu/RendererTest.kt
@@ -559,25 +559,25 @@ class RendererTest {
     private val paletteSpr2 = 3 // Non-zero palette
     private val paletteBg = 2   // Non-zero palette different to that of sprites
 
-    private val ubg = 0
-    private val bgEntry = 1 + (paletteBg * NUM_ENTRIES_PER_PALETTE)
+    private val bgOpqaueEntry = 1 + (paletteBg * NUM_ENTRIES_PER_PALETTE)
+    private val bgTransparentEntry = 0 + (paletteBg * NUM_ENTRIES_PER_PALETTE)
     private val sprEntry = 1 + ((NUM_PALETTES + paletteSpr) * NUM_ENTRIES_PER_PALETTE)
     private val sprEntry2 = 1 + ((NUM_PALETTES + paletteSpr2) * NUM_ENTRIES_PER_PALETTE)
 
     @Test
-    fun `transparent bg, transparent spr, in front - ubg`() {
+    fun `transparent bg, transparent spr, in front - transparent`() {
       initBackground(false)
       initSprite(behind = false, opaque = false, palette = paletteSpr)
 
-      assertPixelColour(expected = ubg)
+      assertPixelColour(expected = bgTransparentEntry)
     }
 
     @Test
-    fun `transparent bg, transparent spr, behind - ubg`() {
+    fun `transparent bg, transparent spr, behind - transparent`() {
       initBackground(false)
       initSprite(behind = true, opaque = false, palette = paletteSpr)
 
-      assertPixelColour(expected = ubg)
+      assertPixelColour(expected = bgTransparentEntry)
     }
 
     @Test
@@ -601,7 +601,7 @@ class RendererTest {
       initBackground(true)
       initSprite(behind = false, opaque = false, palette = paletteSpr)
 
-      assertPixelColour(expected = bgEntry)
+      assertPixelColour(expected = bgOpqaueEntry)
     }
 
     @Test
@@ -609,7 +609,7 @@ class RendererTest {
       initBackground(true)
       initSprite(behind = true, opaque = false, palette = paletteSpr)
 
-      assertPixelColour(expected = bgEntry)
+      assertPixelColour(expected = bgOpqaueEntry)
     }
 
     @Test
@@ -625,7 +625,7 @@ class RendererTest {
       initBackground(true)
       initSprite(behind = true, opaque = true, palette = paletteSpr)
 
-      assertPixelColour(expected = bgEntry)
+      assertPixelColour(expected = bgOpqaueEntry)
     }
 
     @Test
@@ -652,7 +652,7 @@ class RendererTest {
       initSprite(behind = true, opaque = true, palette = paletteSpr, iSprite = 0)
       initSprite(behind = false, opaque = true, palette = paletteSpr2, iSprite = 1)
 
-      assertPixelColour(expected = bgEntry) // Behind sprite wins, so we see the background!
+      assertPixelColour(expected = bgOpqaueEntry) // Behind sprite wins, so we see the background!
     }
 
     @Test
@@ -675,7 +675,7 @@ class RendererTest {
     }
 
     private fun initBackground(opaque: Boolean) {
-      paletteIndices[0] = if (opaque) bgEntry else 0
+      paletteIndices[0] = if (opaque) bgOpqaueEntry else bgTransparentEntry
     }
 
     private fun assertPixelColour(expected: Int) {

--- a/src/test/kotlin/choliver/nespot/ppu/RendererTest.kt
+++ b/src/test/kotlin/choliver/nespot/ppu/RendererTest.kt
@@ -42,15 +42,15 @@ class RendererTest {
     }
 
     @Test
-    fun `patterns for higher palettes use universal background color`() {
+    fun `patterns for higher palette`() {
       val pattern = listOf(0, 1, 2, 3, 2, 3, 0, 1)
-      val attrEntries = List(NUM_METATILE_COLUMNS) { 1 }  // Arbitrary non-zero palette #
+      val attrEntries = List(NUM_METATILE_COLUMNS) { 3 }  // Arbitrary non-zero palette #
       initAttributeMemory(attrEntries)
       initBgPatternMemory(mapOf(0 to pattern))
 
       render()
 
-      assertBuffer { pattern[it % TILE_SIZE].let { if (it == 0) 0 else (it + NUM_ENTRIES_PER_PALETTE) } }
+      assertBuffer { pattern[it % TILE_SIZE] + (3 * NUM_ENTRIES_PER_PALETTE) }
     }
 
     @Test
@@ -790,7 +790,7 @@ class RendererTest {
     }
 
     @Test
-    fun `maps colours`() {
+    fun `maps colours accounting for UBG`() {
       repeat(32) {
         paletteIndices[it] = it
       }
@@ -798,7 +798,10 @@ class RendererTest {
       commit()
 
       repeat(32) {
-        assertEquals(colors[paletteEntries[it]], videoBuffer[Y_SCANLINE * SCREEN_WIDTH + it])
+        assertEquals(
+          colors[paletteEntries[if (it % 4 == 0) 0 else it]], // UBG logic
+          videoBuffer[Y_SCANLINE * SCREEN_WIDTH + it]
+        )
       }
     }
 
@@ -811,7 +814,10 @@ class RendererTest {
       commit(true)
 
       repeat(32) {
-        assertEquals(colors[paletteEntries[it] and 0x30], videoBuffer[Y_SCANLINE * SCREEN_WIDTH + it])
+        assertEquals(
+          colors[paletteEntries[if (it % 4 == 0) 0 else it] and 0x30],  // UBG logic + greyscale
+          videoBuffer[Y_SCANLINE * SCREEN_WIDTH + it]
+        )
       }
     }
 


### PR DESCRIPTION
We're now up to ~800 fps (from ~450 fps).

- `MirroringMemory` + `Mmc1Mapper`
  - switch to a real function rather than function references (Kotlin was doing boxing/unboxing on the return value).
- `NromMapper`
  - pull `usingChrRam` check out of the hot loop.  (**TODO: should we do this across all mappers?**).
- `CpuMapper`
  - optimise order of `when` conditions.
- `Nes`
  - pull memory-write interception out of the hot loop for non-debug mode.
- `Cpu`
  - merge the interrupt callbacks into one.
- `InstructionDecoder`
  - don't created instances of type `Decoded`.
- `Apu`
  - ensure synth timers start up on reasonable frequencies.
  - eliminate hot-loop references to `CYCLES_PER_SAMPLE` from another file.- `Apu` (etc.) - eliminate `observable` properties.
- `Ppu`
  - optimise `incrementFramePos`.
- `Renderer`
  - massive unroll of `loadAndRenderBackground`, based on aligning to tile loads.
  - lazy loads in `evaluateSprites`.
  - move `anyOpaqueSpr` to a bitmap (to minimise time taken to clear).
  - move UBG logic into colour lookup.
  - calculate `palette * 4` once per tile, rather than once per pixel (becomes `paletteBase`).
- Prevent Kotlin runtime non-null checks.