### PR TITLE
Limit Timer in a better way

### DIFF
--- a/src/main/kotlin/choliver/nespot/apu/Timer.kt
+++ b/src/main/kotlin/choliver/nespot/apu/Timer.kt
@@ -8,25 +8,32 @@ class Timer(
   private val cyclesPerSample: Rational = CYCLES_PER_SAMPLE
 ) {
   private var pos = 0
-  private var jump = cyclesPerSample.b
-  var periodCycles = 1
+  private var dec = cyclesPerSample.a
+  private var inc = cyclesPerSample.b
+  var periodCycles = MIN_PERIOD
     set(value) {
       field = value
-      jump = max(value, MIN_PERIOD) * cyclesPerSample.b
+      if (periodCycles >= MIN_PERIOD) {
+        inc = value * cyclesPerSample.b
+        dec = cyclesPerSample.a
+      } else {
+        inc = 1
+        dec = 0
+      }
     }
 
   fun take(): Int {
-    pos -= cyclesPerSample.a
-    val ticks = max(0, (jump - pos) / jump)
-    pos += ticks * jump
+    pos -= dec
+    val ticks = max(0, (inc - pos) / inc)
+    pos += ticks * inc
     return ticks
   }
 
   fun restart() {
-    pos = jump
+    pos = inc
   }
 
   companion object {
-    const val MIN_PERIOD = 8    // Prevents performance issues (as well as divide-by-zero)
+    const val MIN_PERIOD = 3    // Prevents audio aliasing, divide-by-zero, and mitigates perf issues
   }
 }

--- a/src/test/kotlin/choliver/nespot/apu/TimerTest.kt
+++ b/src/test/kotlin/choliver/nespot/apu/TimerTest.kt
@@ -1,5 +1,6 @@
 package choliver.nespot.apu
 
+import choliver.nespot.apu.Timer.Companion.MIN_PERIOD
 import choliver.nespot.toRational
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -82,14 +83,13 @@ class TimerTest {
   }
 
   @Test
-  fun `enforces minimum period`() {
+  fun `disabled if below minimum period`() {
     val timer = Timer(cyclesPerSample = 16.toRational()).apply {
-      periodCycles = 7
+      periodCycles = MIN_PERIOD - 1
     }
 
-    // Same as pattern for periodCycles = 8
     assertEquals(
-      listOf(2).repeat(20).adjustForStartup(),
+      listOf(0).repeat(20).adjustForStartup(),
       timer.take(20)
     )
   }


### PR DESCRIPTION
Deals with triangle synth issues:

- Reduce the minimum period, as triangle period 32*P (so in the audible range for longer).
- Disable the timer entirely when below threshold - prevents aliasing for triangle synth. 