### PR TITLE
Accurately model cycle count when operand requires crossing page boundary

### DIFF
--- a/src/main/kotlin/choliver/nespot/cpu/Cpu.kt
+++ b/src/main/kotlin/choliver/nespot/cpu/Cpu.kt
@@ -11,6 +11,7 @@ import choliver.nespot.cpu.model.State
 import choliver.nespot.cpu.model.toFlags
 import choliver.nespot.cpu.utils._0
 import choliver.nespot.cpu.utils._1
+import choliver.nespot.cpu.utils.samePage
 
 class Cpu(
   private val memory: Memory,
@@ -226,8 +227,8 @@ class Cpu(
   private fun Regs.branch(cond: Boolean) {
     if (cond) {
       extraCycles++
-      if (((pc xor decoded.addr) and 0xFF00) != 0) {
-        extraCycles++   // Page change
+      if (!samePage(pc, decoded.addr)) {
+        extraCycles++
       }
       pc = decoded.addr
     }

--- a/src/main/kotlin/choliver/nespot/cpu/InstructionDecoder.kt
+++ b/src/main/kotlin/choliver/nespot/cpu/InstructionDecoder.kt
@@ -46,7 +46,7 @@ class InstructionDecoder(private val memory: Memory) {
         pcInc = 1
       }
       IMMEDIATE -> {
-        addr = memory[pc + 1] // TODO - kind of a cheat
+        addr = memory[pc + 1]
         pcInc = 2
       }
       INDIRECT -> {

--- a/src/main/kotlin/choliver/nespot/cpu/utils/Utils.kt
+++ b/src/main/kotlin/choliver/nespot/cpu/utils/Utils.kt
@@ -1,7 +1,10 @@
 package choliver.nespot.cpu.utils
 
+import choliver.nespot.Address
+
 @Suppress("ObjectPropertyName")
 const val _0 = false
 @Suppress("ObjectPropertyName")
 const val _1 = true
 
+fun samePage(a: Address, b: Address) = ((a xor b) and 0xFF00) == 0

--- a/src/test/kotlin/choliver/nespot/cpu/CyclesTest.kt
+++ b/src/test/kotlin/choliver/nespot/cpu/CyclesTest.kt
@@ -2,12 +2,14 @@ package choliver.nespot.cpu
 
 import choliver.nespot.cpu.model.Flags
 import choliver.nespot.cpu.model.Instruction
+import choliver.nespot.cpu.model.Opcode
 import choliver.nespot.cpu.model.Opcode.*
+import choliver.nespot.cpu.model.Operand.*
 import choliver.nespot.cpu.model.Operand.IndexSource.X
-import choliver.nespot.cpu.model.Operand.Relative
-import choliver.nespot.cpu.model.Operand.ZeroPageIndexed
+import choliver.nespot.cpu.model.Operand.IndexSource.Y
 import choliver.nespot.cpu.model.Regs
 import choliver.nespot.cpu.utils._1
+import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 
 class CyclesTest {
@@ -22,6 +24,7 @@ class CyclesTest {
       expectedCycles = 6
     )
   }
+
   @Test
   fun `models variable number of branch instructions`() {
     // Untaken
@@ -50,5 +53,100 @@ class CyclesTest {
       initRegs = Regs(p = Flags(z = _1)),
       expectedCycles = 4
     )
+  }
+
+  @Nested
+  inner class OperandPageCrossing {
+    private val standardOps = listOf(ADC, AND, CMP, EOR, LDA, ORA, SBC)
+
+    @Test
+    fun `absolute indexed x`() {
+      (standardOps + LDY).forEach { op ->
+        assertAbsoluteIndexed(op, X, 4, 5)
+      }
+    }
+
+    @Test
+    fun `absolute indexed y`() {
+      (standardOps + LDX).forEach { op ->
+        assertAbsoluteIndexed(op, Y, 4, 5)
+      }
+    }
+
+    @Test
+    fun `indirect indexed`() {
+      standardOps.forEach { op ->
+        assertIndirectIndexed(op, 5, 6)
+      }
+    }
+
+    @Test
+    fun `absolute indexed x - no variations for exceptions`() {
+      listOf(INC, DEC, ASL, LSR, ROL, ROR).forEach { op ->
+        assertAbsoluteIndexed(op, X, 7, 7)
+      }
+    }
+
+    @Test
+    fun `STA - no variations`() {
+      assertAbsoluteIndexed(STA, X, 5, 5)
+      assertAbsoluteIndexed(STA, Y, 5, 5)
+      assertIndirectIndexed(STA, 6, 6)
+    }
+
+    private fun assertAbsoluteIndexed(op: Opcode, source: IndexSource, normalCycles: Int, pageCrossedCycles: Int) {
+      val initRegs = when (source) {
+        X -> Regs(x = 0x30)
+        Y -> Regs(y = 0x30)
+      }
+
+      // Regular
+      assertCpuEffects(
+        instructions = listOf(
+          Instruction(op, AbsoluteIndexed(0x12CF, source))
+        ),
+        initRegs = initRegs,
+        expectedStores = null,
+        expectedCycles = normalCycles,
+        name = op.name
+      )
+
+      // Crosses page boundary
+      assertCpuEffects(
+        instructions = listOf(
+          Instruction(op, AbsoluteIndexed(0x12D0, source))
+        ),
+        initRegs = initRegs,
+        expectedStores = null,
+        expectedCycles = pageCrossedCycles,
+        name = op.name
+      )
+    }
+
+    private fun assertIndirectIndexed(op: Opcode, normalCycles: Int, pageCrossedCycles: Int) {
+      // Regular
+      assertCpuEffects(
+        instructions = listOf(
+          Instruction(op, IndirectIndexed(0x12))
+        ),
+        initRegs = Regs(y = 0x30),
+        initStores = listOf(0x12 to 0x12CF),
+        expectedStores = null,
+        expectedCycles = normalCycles,
+        name = op.name
+      )
+
+      // Crosses page boundary
+      assertCpuEffects(
+        instructions = listOf(
+          Instruction(op, IndirectIndexed(0x12))
+        ),
+        initRegs = Regs(y = 0x30),
+        initStores = listOf(0x12 to 0x12D0),
+        expectedStores = null,
+        expectedCycles = pageCrossedCycles,
+        name = op.name
+      )
+    }
   }
 }

--- a/src/test/kotlin/choliver/nespot/cpu/Utils.kt
+++ b/src/test/kotlin/choliver/nespot/cpu/Utils.kt
@@ -128,7 +128,7 @@ fun assertCpuEffects(
   initRegs: Regs,
   initStores: List<Pair<Address, Data>> = emptyList(),
   expectedRegs: Regs? = null,
-  expectedStores: List<Pair<Address, Data>> = emptyList(),
+  expectedStores: List<Pair<Address, Data>>? = emptyList(), // null == no check
   expectedCycles: Int? = null,
   pollReset: (iStep: Int) -> Boolean = { _0 },
   pollNmi: (iStep: Int) -> Boolean = { _0 },
@@ -161,7 +161,9 @@ fun assertCpuEffects(
     assertEquals(expectedRegs, cpu.diagnostics.state.regs, "Unexpected registers for [${name}]")
   }
 
-  verifyStores(memory, expectedStores)
+  if (expectedStores != null) {
+    verifyStores(memory, expectedStores)
+  }
 
   if (expectedCycles != null) {
     assertEquals(expectedCycles, numCycles, "Unexpected # cycles for [${name}]")

--- a/src/test/kotlin/choliver/nespot/runner/TestRomsTest.kt
+++ b/src/test/kotlin/choliver/nespot/runner/TestRomsTest.kt
@@ -26,7 +26,7 @@ class TestRomsTest {
   fun `cpu_interrupts_v2 - nmi_and_brk`() = run("cpu_interrupts_v2/rom_singles/2-nmi_and_brk.nes")
 
   @Test
-  fun `cpu_interrupts_v2 - nmåi_and_irq`() = run("cpu_interrupts_v2/rom_singles/3-nmi_and_irq.nes")
+  fun `cpu_interrupts_v2 - nmi_and_irq`() = run("cpu_interrupts_v2/rom_singles/3-nmi_and_irq.nes")
 
   @Test
   fun `cpu_interrupts_v2 - irq_and_dma`() = run("cpu_interrupts_v2/rom_singles/4-irq_and_dma.nes")


### PR DESCRIPTION
- Fixes #76.
- Test ROM `cpu_timing_test6/cpu_timing_test.nes` now passes.