### PR TITLE
DMC samples can only start on octet boundaries

### DIFF
--- a/src/commonMain/kotlin/choliver/nespot/Memory.kt
+++ b/src/commonMain/kotlin/choliver/nespot/Memory.kt
@@ -3,5 +3,5 @@ package choliver.nespot
 // TODO - should Memory be responsible for wrapping OOB addresses?
 interface Memory {
   operator fun get(addr: Address): Data
-  operator fun set(addr: Address, data: Data)
+  operator fun set(addr: Address, data: Data) {}
 }

--- a/src/commonMain/kotlin/choliver/nespot/apu/DmcSynth.kt
+++ b/src/commonMain/kotlin/choliver/nespot/apu/DmcSynth.kt
@@ -6,7 +6,6 @@ import choliver.nespot.Memory
 import kotlin.math.max
 import kotlin.math.min
 
-
 // See http://wiki.nesdev.com/w/index.php/APU_DMC
 class DmcSynth(private val memory: Memory) : Synth {
   private val memoryUnit = MemoryUnit()

--- a/src/commonMain/kotlin/choliver/nespot/apu/DmcSynth.kt
+++ b/src/commonMain/kotlin/choliver/nespot/apu/DmcSynth.kt
@@ -9,10 +9,9 @@ import kotlin.math.min
 
 // See http://wiki.nesdev.com/w/index.php/APU_DMC
 class DmcSynth(private val memory: Memory) : Synth {
-  private var addrCurrent: Address = 0x0000
-  private var numBitsRemaining = 0
-  private var numBytesRemaining = 0
-  private var sample: Data = 0
+  private val memoryUnit = MemoryUnit()
+  private val outputUnit = OutputUnit()
+  private var sample: Data? = null
   private var _irq = false
 
   var irqEnabled = false
@@ -29,62 +28,79 @@ class DmcSynth(private val memory: Memory) : Synth {
     set(value) {
       field = value
       when {
-        (value && (numBytesRemaining == 0)) -> restart()
-        !value -> clear()
+        (value && (memoryUnit.numRemaining == 0)) -> memoryUnit.restart()
+        !value -> memoryUnit.clear()
       }
       _irq = false
     }
-  override val hasRemainingOutput get() = numBytesRemaining > 0
+  override val hasRemainingOutput get() = memoryUnit.numRemaining > 0
   override val output get() = level
 
   val irq get() = _irq
 
   override fun onTimer(num: Int) {
     for (i in 0 until num) {
-      maybeLoadSample()
-      maybePlaySample()
+      memoryUnit.update()
+      outputUnit.update()
     }
   }
 
-  private fun maybeLoadSample() {
-    if ((numBitsRemaining == 0) && (numBytesRemaining > 0)) {
-      sample = memory[addrCurrent]
-      numBitsRemaining = 8
+  private inner class MemoryUnit {
+    var numRemaining = 0
+    private var addrCurrent: Address = 0x0000
 
-      if (addrCurrent == 0xFFFF) {
-        addrCurrent = 0x8000
-      } else {
-        addrCurrent++
-      }
+    fun update() {
+      if ((sample == null) && (numRemaining > 0)) {
+        sample = memory[addrCurrent]
 
-      numBytesRemaining--
-      if (numBytesRemaining == 0) {
-        if (loop) {
-          restart()
-        } else if (irqEnabled) {
-          _irq = true
+        addrCurrent = when (addrCurrent) {
+          0xFFFF -> 0x8000
+          else -> (addrCurrent + 1)
+        }
+
+        if (--numRemaining == 0) {
+          when {
+            loop -> restart()
+            irqEnabled -> _irq = true
+          }
         }
       }
     }
-  }
 
-  private fun maybePlaySample() {
-    if (numBitsRemaining != 0) {
-      when (sample and 1) {
-        1 -> level = min(level + 2, 125)
-        0 -> level = max(level - 2, 2)
-      }
-      sample = sample shr 1
-      numBitsRemaining--
+    fun restart() {
+      numRemaining = length
+      addrCurrent = address
+    }
+
+    fun clear() {
+      numRemaining = 0
     }
   }
 
-  fun restart() {
-    numBytesRemaining = length
-    addrCurrent = address
-  }
+  private inner class OutputUnit {
+    private var silence = true
+    private var sr: Data = 0
+    private var numRemaining = 8
 
-  fun clear() {
-    numBytesRemaining = 0
+    fun update() {
+      if (!silence) {
+        when (sr and 1) {
+          1 -> level = min(level + 2, 125)
+          0 -> level = max(level - 2, 2)
+        }
+        sr = sr shr 1
+      }
+
+      if (--numRemaining == 0) {
+        numRemaining = 8
+        if (sample != null) {
+          silence = false
+          sr = sample!!
+          sample = null
+        } else {
+          silence = true
+        }
+      }
+    }
   }
 }

--- a/src/commonMain/kotlin/choliver/nespot/nes/Nes.kt
+++ b/src/commonMain/kotlin/choliver/nespot/nes/Nes.kt
@@ -17,12 +17,18 @@ class Nes(
   private val onStore: ((Address, Data) -> Unit)? = null
 ) {
   private var steps = 0
+  private var extraCycles = 0
 
   private val mapper = createMapper(rom, getStepCount = { steps })
 
+  private val apuInterceptor = object : Memory {
+    override fun get(addr: Address) = mapper.prg[addr]  // DMC can only read from PRG space
+      .also { extraCycles += 3 }
+  }
+
   private val apu = Apu(
     cpuFreqHz = CPU_FREQ_HZ,
-    memory = mapper.prg,  // DMC can only read from PRG space
+    memory = apuInterceptor,
     audioSink = audioSink
   )
 
@@ -50,10 +56,11 @@ class Nes(
 
   fun step(): Int {
     val cycles = cpu.executeStep()
+    extraCycles = 0
     apu.advance(cycles)
-    ppu.advance(cycles)
+    ppu.advance(cycles + extraCycles)
     steps++
-    return cycles
+    return cycles + extraCycles
   }
 
   private fun pollInterrupts() = (if (apu.irq || mapper.irq) INTERRUPT_IRQ else 0) or (if (ppu.vbl) INTERRUPT_NMI else 0)

--- a/src/jvmTest/kotlin/choliver/nespot/apu/DmcSynthTest.kt
+++ b/src/jvmTest/kotlin/choliver/nespot/apu/DmcSynthTest.kt
@@ -221,6 +221,28 @@ class DmcSynthTest {
     assertEquals(expected, seq1 + seq2)
   }
 
+  @Test
+  fun `sample can only start on octet boundaries`() {
+    synth.length = 2
+    synth.enabled = true
+    whenever(memory[0xC230]) doReturn 0xFF
+    whenever(memory[0xC231]) doReturn 0xAA
+
+    skipWarmupSamples()
+    val seq1 = synth.take(16 + 4)  // Part way into silence octet
+    synth.enabled = true
+    val seq2 = synth.take(4 + 16)
+
+    val expected = listOf(
+      2,  4,  6,  8,  10, 12, 14, 16,   // Sample
+      14, 16, 14, 16, 14, 16, 14, 16,   // "
+      16, 16, 16, 16, 16, 16, 16, 16,   // Silence
+      18, 20, 22, 24, 26, 28, 30, 32,   // Sample starts on octet boundary
+      30, 32, 30, 32, 30, 32, 30, 32    // "
+    )
+    assertEquals(expected, seq1 + seq2)
+  }
+
   // TODO - play what's left on disable
 
   private fun skipWarmupSamples() = synth.take(9) // 1 for output-before-advance, 8 for no-sample-loaded

--- a/src/jvmTest/kotlin/choliver/nespot/apu/DmcSynthTest.kt
+++ b/src/jvmTest/kotlin/choliver/nespot/apu/DmcSynthTest.kt
@@ -7,7 +7,6 @@ import com.nhaarman.mockitokotlin2.whenever
 import org.junit.jupiter.api.Assertions.*
 import org.junit.jupiter.api.Test
 
-// TODO - wraparound
 class DmcSynthTest {
   private val memory = mock<Memory>()
   private val synth = DmcSynth(memory = memory).apply {
@@ -30,16 +29,16 @@ class DmcSynthTest {
       whenever(memory[0xC230 + i]) doReturn (if (i % 2 == 0) 0xFF else 0xAA)  // Nice bit patterns
     }
 
+    skipWarmupSamples()
+
     val expected = listOf(
-      0,
       2,  4,  6,  8,  10, 12, 14, 16,   // Up up up
       14, 16, 14, 16, 14, 16, 14, 16,   // Down and up
       18, 20, 22, 24, 26, 28, 30, 32,   // Up up up
       30, 32, 30, 32, 30, 32, 30, 32,   // Down and up
       34, 36, 38, 40, 42, 44, 46, 48    // Up up up
     )
-
-    assertEquals(expected, synth.take(41))
+    assertEquals(expected, synth.take(40))
   }
 
   @Test
@@ -50,13 +49,13 @@ class DmcSynthTest {
     whenever(memory[0xFFFF]) doReturn 0xFF
     whenever(memory[0x8000]) doReturn 0xAA
 
+    skipWarmupSamples()
+
     val expected = listOf(
-      0,
       2,  4,  6,  8,  10, 12, 14, 16,   // Up up up
       14, 16, 14, 16, 14, 16, 14, 16    // Down and up
     )
-
-    assertEquals(expected, synth.take(17))
+    assertEquals(expected, synth.take(16))
   }
 
   @Test
@@ -66,14 +65,14 @@ class DmcSynthTest {
     whenever(memory[0xC230]) doReturn 0xFF
     whenever(memory[0xC231]) doReturn 0xAA
 
+    skipWarmupSamples()
+
     val expected = listOf(
-      0,
       2,  4,  6,  8,  10, 12, 14, 16,
       14, 16, 14, 16, 14, 16, 14, 16,
       16, 16, 16, 16
     )
-
-    assertEquals(expected, synth.take(21))
+    assertEquals(expected, synth.take(20))
   }
 
   @Test
@@ -85,15 +84,15 @@ class DmcSynthTest {
     whenever(memory[0xC230]) doReturn 0xFF
     whenever(memory[0xC231]) doReturn 0xAA
 
+    skipWarmupSamples()
+
     val expected = listOf(
-      0,
       2,  4,  6,  8,  10, 12, 14, 16,   // Up up up
       14, 16, 14, 16, 14, 16, 14, 16,   // Down and up
       18, 20, 22, 24, 26, 28, 30, 32,   // Up up up
       30, 32, 30, 32, 30, 32, 30, 32    // Down and up
     )
-
-    assertEquals(expected, synth.take(33))
+    assertEquals(expected, synth.take(32))
     assertFalse(synth.irq)
   }
 
@@ -106,15 +105,15 @@ class DmcSynthTest {
     whenever(memory[0xC230]) doReturn 0xFF
     whenever(memory[0xC231]) doReturn 0xAA
 
+    skipWarmupSamples()
+
     val expected = listOf(
-      0,
       2,  4,  6,  8,  10, 12, 14, 16,   // Up up up
       14, 16, 14, 16, 14, 16, 14, 16,   // Down and up
       16, 16, 16, 16, 16, 16, 16, 16,
       16, 16, 16, 16, 16, 16, 16, 16
     )
-
-    assertEquals(expected, synth.take(33))
+    assertEquals(expected, synth.take(32))
     assertTrue(synth.irq)
   }
 
@@ -125,12 +124,12 @@ class DmcSynthTest {
     synth.level = 7
     whenever(memory[0xC230]) doReturn 0x00 // Dowm down down
 
+    skipWarmupSamples()
+
     val expected = listOf(
-      7,
       5, 3, 2, 2, 2, 2, 2, 2
     )
-
-    assertEquals(expected, synth.take(9))
+    assertEquals(expected, synth.take(8))
   }
 
   @Test
@@ -140,12 +139,12 @@ class DmcSynthTest {
     synth.level = 120
     whenever(memory[0xC230]) doReturn 0xFF // Up up up
 
+    skipWarmupSamples()
+
     val expected = listOf(
-      120,
       122, 124, 125, 125, 125, 125, 125, 125
     )
-
-    assertEquals(expected, synth.take(9))
+    assertEquals(expected, synth.take(8))
   }
 
   @Test
@@ -189,16 +188,15 @@ class DmcSynthTest {
     whenever(memory[0xC230]) doReturn 0xFF
     whenever(memory[0xC231]) doReturn 0xAA
 
+    skipWarmupSamples()
     val seq1 = synth.take(4)
     synth.enabled = true
-    val seq2 = synth.take(13)
+    val seq2 = synth.take(12)
 
     val expected = listOf(
-      0,
       2,  4,  6,  8,  10, 12, 14, 16,   // Up up up
       14, 16, 14, 16, 14, 16, 14, 16    // Down and up
     )
-
     assertEquals(expected, seq1 + seq2)
   }
 
@@ -209,20 +207,21 @@ class DmcSynthTest {
     whenever(memory[0xC230]) doReturn 0xFF
     whenever(memory[0xC231]) doReturn 0xAA
 
-    val seq1 = synth.take(9)  // Just after final load
+    skipWarmupSamples()
+    val seq1 = synth.take(8)  // Just after final load
     synth.enabled = true
     val seq2 = synth.take(24)
 
     val expected = listOf(
-      0,
       2,  4,  6,  8,  10, 12, 14, 16,   // Up up up
       14, 16, 14, 16, 14, 16, 14, 16,   // Down and up
       18, 20, 22, 24, 26, 28, 30, 32,   // Up up up
       30, 32, 30, 32, 30, 32, 30, 32    // Down and up
     )
-
     assertEquals(expected, seq1 + seq2)
   }
 
   // TODO - play what's left on disable
+
+  private fun skipWarmupSamples() = synth.take(9) // 1 for output-before-advance, 8 for no-sample-loaded
 }


### PR DESCRIPTION
Improves (but doesn't fully fix) MIG-29 behaviour (#96).