### PR TITLE
Reduce controller sample rate to 10ms

### DIFF
--- a/src/jvmMain/kotlin/choliver/nespot/ui/ControllerManager.kt
+++ b/src/jvmMain/kotlin/choliver/nespot/ui/ControllerManager.kt
@@ -110,6 +110,6 @@ class ControllerManager(
   }
 
   companion object {
-    private const val SAMPLE_PERIOD_MS = 1L
+    private const val SAMPLE_PERIOD_MS = 10L
   }
 }


### PR DESCRIPTION
Empirically this seems to work a lot better.

Perhaps aggressive sampling was causing jankware issues in Jinput.